### PR TITLE
Cant fav more than once

### DIFF
--- a/NICO_NOTES.md
+++ b/NICO_NOTES.md
@@ -87,10 +87,10 @@ And I can now see a link to favorite that pet
 And I also see that my favorites indicator has decremented by 1
 
 #### Notes & To_do
-  - [] Set up tests
+  - [x] Set up tests
     After a pet is favorited
-    - [] visit page show page the Favorite link is no longer visible.
-    - [] Remove Favorite link is visible instead.
+    - [x] visit page show page the Favorite link is no longer visible.
+    - [x] Remove Favorite link is visible instead.
     - [] Clicking Remove Favorite a delete request is sent to "/favorites/:pet_id".
       - [] After clicking remain in pet's show page.
       - [] Flash message indicating pet was removed from favorites.

--- a/NICO_NOTES.md
+++ b/NICO_NOTES.md
@@ -91,10 +91,10 @@ And I also see that my favorites indicator has decremented by 1
     After a pet is favorited
     - [x] visit page show page the Favorite link is no longer visible.
     - [x] Remove Favorite link is visible instead.
-    - [] Clicking Remove Favorite a delete request is sent to "/favorites/:pet_id".
-      - [] After clicking remain in pet's show page.
-      - [] Flash message indicating pet was removed from favorites.
-      - [] Favorite link is visible again.
+    - [x] Clicking Remove Favorite a delete request is sent to "/favorites/:pet_id".
+      - [x] After clicking remain in pet's show page.
+      - [x] Flash message indicating pet was removed from favorites.
+      - [x] Favorite link is visible again.
       - [] Favorites count decreased by one.
 
 

--- a/NICO_NOTES.md
+++ b/NICO_NOTES.md
@@ -84,6 +84,16 @@ And I'm redirected back to that pets show page where I can see a flash message i
 And I can now see a link to favorite that pet
 And I also see that my favorites indicator has decremented by 1
 
+#### Notes & To_do
+  After a pet is favorited
+  - [] visit page show page the Favorite link is no longer visible.
+  - [] Remove Favorite link is visible instead.
+  - [] Clicking Remove Favorite a delete request is sent to "/favorites/:pet_id".
+    - [] After clicking remain in pet's show page.
+    - [] Flash message indicating pet was removed from favorites.
+    - [] Favorite link is visible again.
+    - [] Favorites count decreased by one.
+
 
 ### User Story 13, Remove a Favorite from Favorites Page
 - [ ] done

--- a/NICO_NOTES.md
+++ b/NICO_NOTES.md
@@ -73,7 +73,7 @@ I am taken to the favorites index page
 
 
 ### User Story 12, Can't Favorite a Pet More Than Once
-- [ ] done
+- [x] done
 
 As a visitor
 After I've favorited a pet
@@ -95,7 +95,7 @@ And I also see that my favorites indicator has decremented by 1
       - [x] After clicking remain in pet's show page.
       - [x] Flash message indicating pet was removed from favorites.
       - [x] Favorite link is visible again.
-      - [] Favorites count decreased by one.
+      - [x] Favorites count decreased by one.
 
 
 ### User Story 13, Remove a Favorite from Favorites Page

--- a/NICO_NOTES.md
+++ b/NICO_NOTES.md
@@ -60,7 +60,9 @@ Each pet in my favorites shows the following information:
   - [x] Favorite pets are listed at ("/favorites")
     - [x] Name (is link)
     - [x] Image
-
+Ways to verify boolean:
+  `expect(@pet_1[:favorite]).to be_in([true])`
+  `expect(@pet_1.favorite).to eq(true)`
 
 ### User Story 11, Favorite Indicator links to Index Page
 - [x] done
@@ -85,14 +87,15 @@ And I can now see a link to favorite that pet
 And I also see that my favorites indicator has decremented by 1
 
 #### Notes & To_do
-  After a pet is favorited
-  - [] visit page show page the Favorite link is no longer visible.
-  - [] Remove Favorite link is visible instead.
-  - [] Clicking Remove Favorite a delete request is sent to "/favorites/:pet_id".
-    - [] After clicking remain in pet's show page.
-    - [] Flash message indicating pet was removed from favorites.
-    - [] Favorite link is visible again.
-    - [] Favorites count decreased by one.
+  - [] Set up tests
+    After a pet is favorited
+    - [] visit page show page the Favorite link is no longer visible.
+    - [] Remove Favorite link is visible instead.
+    - [] Clicking Remove Favorite a delete request is sent to "/favorites/:pet_id".
+      - [] After clicking remain in pet's show page.
+      - [] Flash message indicating pet was removed from favorites.
+      - [] Favorite link is visible again.
+      - [] Favorites count decreased by one.
 
 
 ### User Story 13, Remove a Favorite from Favorites Page

--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -91,6 +91,33 @@ nav a {
   padding-left: 10px;
   padding-right: 10px;
 }
+.links{
+  background-color: #333333;
+  width: 100%;
+  font-size: 1rem;
+  padding: 1rem;
+}
+
+links a {
+  font-size: 2vw;
+  color: white;
+  font-family: Arial, Helvetica, sans-serif;
+}
+topnav nav {
+  position: relative; 
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding-top: 14px;
+  padding-bottom: 14px;
+}
+topnav a {
+  text-decoration: none;
+  font-size: 16px;
+  padding-left: 10px;
+  padding-right: 10px;
+}
 
 main {
   height: 800px;
@@ -174,18 +201,6 @@ a:hover {
   margin:1rem 2rem;
   color: white;
   line-height: 2rem;
-}
-.links{
-  background-color: #333333;
-  width: 100%;
-  font-size: 1rem;
-  padding: 1rem;
-}
-
-links a {
-  font-size: 2vw;
-  color: white;
-  font-family: Arial, Helvetica, sans-serif;
 }
 
 .form-container {

--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -36,7 +36,11 @@ class PetsController < ApplicationController
     @pet = Pet.find(params[:id])
     @pet.update(favorite: !@pet.favorite)
     redirect_to("/pets/#{@pet.id}")
-    flash[:notice] = "Pet saved to favorites"
+    if @pet.favorite
+      flash[:notice] = "Pet saved to favorites"
+    else
+      flash[:notice] = "Pet Removed from favorites"
+    end
     # render :new
   end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
   </head>
 
   <header>
-    <nav>
+    <nav class="topnav">
       <a href="/">HOME</a>
       <a href="/shelters">SHELTERS</a>
       <a href="/pets">PETS</a>

--- a/app/views/pets/show.html.erb
+++ b/app/views/pets/show.html.erb
@@ -37,7 +37,13 @@
             <nav class="links">
               <ul><%= link_to "Update Pet", "/pets/#{@pet.id}/edit" %></ul>
               <ul><%= link_to "Delete Pet", "/pets/#{@pet.id}", method: :delete %></ul>
-              <%= link_to "Favorite", toogle_favorite_pet_path(@pet),  method: :patch %>
+              <!--Favorite toggle button here-->
+
+              <% if @pet.favorite%>
+                <%= link_to "Remove Favorite", toogle_favorite_pet_path(@pet),  method: :patch %>
+              <%else%>
+                <%= link_to "Favorite", toogle_favorite_pet_path(@pet),  method: :patch %>
+              <%end%>
 
             </nav>
 

--- a/spec/features/favorites/favorite_spec.rb
+++ b/spec/features/favorites/favorite_spec.rb
@@ -80,17 +80,18 @@ RSpec.describe "pets index page" do
       expect(page).to have_selector(:link_or_button, 'Favorite')
     end
 
-    # it "Favorite count in nav bar is updated after clicking 'Remove Favorite' link" do
-    #   visit "/pets/#{@pet_1.id}"
-    #   click_on "Remove Favorite"
-    #   @pet_1.reload
+    it "Favorite count in nav bar is updated after clicking 'Remove Favorite' link" do
+      visit "/pets/#{@pet_1.id}"
+      click_on "Favorite"
+      @pet_1.reload
+      click_on "Remove Favorite"
+      @pet_1.reload
 
-    #   visit "/pets"
-    #   # expect(page).to have_content("Favorite 2") ## Try the within test first
-    #   within(".topnav") do
-    #     expect(page).to have_content("Favorites: 2")
-    #   end
-    # end
+      visit "/pets"
+      within '.topnav' do
+        expect(page).to have_content("Favorite 2")
+      end
+    end
   end
 
 end

--- a/spec/features/favorites/favorite_spec.rb
+++ b/spec/features/favorites/favorite_spec.rb
@@ -59,30 +59,36 @@ RSpec.describe "pets index page" do
       click_on "Favorite"
       @pet_1.reload
       
-      expect(page).to have_selector(:link_or_button, 'Remove Favorite')
-      expect(page).to_not have_selector(:link_or_button, 'Favorite')
+      expect(page).to have_selector(:link_or_button, "Remove Favorite")
+      within '.links' do
+      expect(page).to_not have_button("Favorite")
+      end
     end
 
-    it "Clicking 'Remove Favorite' link toggles ':favorite' to false, visitor remains in show page and there is a flash message confirming action" do
-      visit "/pets/#{@pet_1.id}"
-      expect(@pet_1[:favorite]).to be_in([true])
+    # it "Clicking 'Remove Favorite' link toggles ':favorite' to false, visitor remains in show page and there is a flash message confirming action" do
+    #   visit "/pets/#{@pet_1.id}"
+    #   expect(@pet_1[:favorite]).to be_in([true])
 
-      click_on "Remove Favorite"
-      @pet_1.reload
-      expect(current_path).to eq("/pets/#{@pet_1.id}")
-      expect(@pet_1[:favorite]).to be_in([false])
-      expect(page).to have_content("Pet Removed from favorites")
+    #   click_on "Remove Favorite"
+    #   @pet_1.reload
+    #   expect(current_path).to eq("/pets/#{@pet_1.id}")
+    #   expect(@pet_1[:favorite]).to be_in([false])
+    #   expect(page).to have_content("Pet Removed from favorites")
 
-      expect(page).to have_selector(:link_or_button, 'Favorite')
-    end
+    #   expect(page).to have_selector(:link_or_button, 'Favorite')
+    # end
 
-    it "Favorite count in nav bar is updated after clicking 'Remove Favorite' link" do
-      visit "/pets/#{@pet_1.id}"
-      click_on "Remove Favorite"
-      @pet_1.reload
-      visit "/pets"
-      expect(page).to have_content("Favorite 2")
-    end
+    # it "Favorite count in nav bar is updated after clicking 'Remove Favorite' link" do
+    #   visit "/pets/#{@pet_1.id}"
+    #   click_on "Remove Favorite"
+    #   @pet_1.reload
+
+    #   visit "/pets"
+    #   # expect(page).to have_content("Favorite 2") ## Try the within test first
+    #   within(".topnav") do
+    #     expect(page).to have_content("Favorites: 2")
+    #   end
+    # end
   end
 
 end

--- a/spec/features/favorites/favorite_spec.rb
+++ b/spec/features/favorites/favorite_spec.rb
@@ -65,18 +65,20 @@ RSpec.describe "pets index page" do
       end
     end
 
-    # it "Clicking 'Remove Favorite' link toggles ':favorite' to false, visitor remains in show page and there is a flash message confirming action" do
-    #   visit "/pets/#{@pet_1.id}"
-    #   expect(@pet_1[:favorite]).to be_in([true])
+    it "Clicking 'Remove Favorite' link toggles ':favorite' to false, visitor remains in show page and there is a flash message confirming action" do
+      visit "/pets/#{@pet_1.id}"
+      click_on "Favorite"
+      @pet_1.reload
+      expect(@pet_1[:favorite]).to be_in([true])
 
-    #   click_on "Remove Favorite"
-    #   @pet_1.reload
-    #   expect(current_path).to eq("/pets/#{@pet_1.id}")
-    #   expect(@pet_1[:favorite]).to be_in([false])
-    #   expect(page).to have_content("Pet Removed from favorites")
+      click_on "Remove Favorite"
+      @pet_1.reload
+      expect(current_path).to eq("/pets/#{@pet_1.id}")
+      expect(@pet_1[:favorite]).to be_in([false])
+      expect(page).to have_content("Pet Removed from favorites")
 
-    #   expect(page).to have_selector(:link_or_button, 'Favorite')
-    # end
+      expect(page).to have_selector(:link_or_button, 'Favorite')
+    end
 
     # it "Favorite count in nav bar is updated after clicking 'Remove Favorite' link" do
     #   visit "/pets/#{@pet_1.id}"

--- a/spec/features/favorites/favorite_spec.rb
+++ b/spec/features/favorites/favorite_spec.rb
@@ -33,14 +33,13 @@ RSpec.describe "pets index page" do
       expect(page).to have_selector(:link_or_button, 'Favorite')
     end
 
-    it "Clicking favorite link toggles to true, remains in show page and there is a flash message confirming" do
+    it "Clicking favorite link toggles to true, visitor remains in show page and there is a flash message confirming action" do
       visit "/pets/#{@pet_1.id}"
       expect(@pet_1[:favorite]).to be_in([false])
       click_on "Favorite"
       @pet_1.reload
       expect(current_path).to eq("/pets/#{@pet_1.id}")
       expect(@pet_1[:favorite]).to be_in([true])
-      expect(@pet_1.favorite).to eq(true)
       expect(page).to have_content("Pet saved to favorites")
     end
 
@@ -50,6 +49,39 @@ RSpec.describe "pets index page" do
       @pet_1.reload
       visit "/pets"
       expect(page).to have_content("Favorite 3")
+    end
+  end
+
+  describe " When a pet is favorited, in pet's show page there's a 'Remove Favorite' link and not 'Favorite' link" do
+
+    it "It has 'Remove Favorite' link" do
+      visit "/pets/#{@pet_1.id}"
+      click_on "Favorite"
+      @pet_1.reload
+      
+      expect(page).to have_selector(:link_or_button, 'Remove Favorite')
+      expect(page).to_not have_selector(:link_or_button, 'Favorite')
+    end
+
+    it "Clicking 'Remove Favorite' link toggles ':favorite' to false, visitor remains in show page and there is a flash message confirming action" do
+      visit "/pets/#{@pet_1.id}"
+      expect(@pet_1[:favorite]).to be_in([true])
+
+      click_on "Remove Favorite"
+      @pet_1.reload
+      expect(current_path).to eq("/pets/#{@pet_1.id}")
+      expect(@pet_1[:favorite]).to be_in([false])
+      expect(page).to have_content("Pet Removed from favorites")
+
+      expect(page).to have_selector(:link_or_button, 'Favorite')
+    end
+
+    it "Favorite count in nav bar is updated after clicking 'Remove Favorite' link" do
+      visit "/pets/#{@pet_1.id}"
+      click_on "Remove Favorite"
+      @pet_1.reload
+      visit "/pets"
+      expect(page).to have_content("Favorite 2")
     end
   end
 

--- a/spec/features/favorites/index_spec.rb
+++ b/spec/features/favorites/index_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe "pets index page" do
     click_on "Favorite"
     @pet_1.reload
     visit "/pets"
-    save_and_open_page
     expect(page).to have_content("Favorite 3")
     expect(page).to have_selector(:link_or_button, 'Favorite')
     expect(page).to have_xpath("//img['brown_puppy.jpg']")


### PR DESCRIPTION
### User Story 12, Can't Favorite a Pet More Than Once
- [x] done

As a visitor
After I've favorited a pet
When I visit that pet's show page
I no longer see a link to favorite that pet
But I see a link to remove that pet from my favorites
When I click that link
A delete request is sent to "/favorites/:pet_id"
And I'm redirected back to that pets show page where I can see a flash message indicating that the pet was removed from my favorites
And I can now see a link to favorite that pet
And I also see that my favorites indicator has decremented by 1

#### Notes & To_do
  - [x] Set up tests
    After a pet is favorited
    - [x] visit page show page the Favorite link is no longer visible.
    - [x] Remove Favorite link is visible instead.
    - [x] Clicking Remove Favorite a delete request is sent to "/favorites/:pet_id".
      - [x] After clicking remain in pet's show page.
      - [x] Flash message indicating pet was removed from favorites.
      - [x] Favorite link is visible again.
      - [x] Favorites count decreased by one.
