### PR TITLE
Remove favorite from favorites

### DIFF
--- a/NICO_NOTES.md
+++ b/NICO_NOTES.md
@@ -116,7 +116,7 @@ And I also see that the favorites indicator has decremented by 1
     - [x] visit my favorites page and a 'remove favorite' link is visible next to EACH pet.
     - [x] Clicking 'Remove Favorite' a delete request is sent to "/favorites/:pet_id".
       - [x] After clicking remain in Favorites page.
-      - [] Favorites count decreased by one.
+      - [x] Favorites count decreased by one.
 
 
 ### User Story 14, No Favorites Page

--- a/NICO_NOTES.md
+++ b/NICO_NOTES.md
@@ -113,9 +113,9 @@ And I also see that the favorites indicator has decremented by 1
 #### Notes & To_do
   - [x] Set up tests
     When I have added pets to my favorites list
-    - [] visit my favorites page and a 'remove favorite' link is visible next to EACH pet.
-    - [] Clicking 'Remove Favorite' a delete request is sent to "/favorites/:pet_id".
-      - [] After clicking remain in Favorites page.
+    - [x] visit my favorites page and a 'remove favorite' link is visible next to EACH pet.
+    - [x] Clicking 'Remove Favorite' a delete request is sent to "/favorites/:pet_id".
+      - [x] After clicking remain in Favorites page.
       - [] Favorites count decreased by one.
 
 

--- a/NICO_NOTES.md
+++ b/NICO_NOTES.md
@@ -110,6 +110,14 @@ A delete request is sent to "/favorites/:pet_id"
 And I'm redirected back to the favorites page where I no longer see that pet listed
 And I also see that the favorites indicator has decremented by 1
 
+#### Notes & To_do
+  - [x] Set up tests
+    When I have added pets to my favorites list
+    - [] visit my favorites page and a 'remove favorite' link is visible next to EACH pet.
+    - [] Clicking 'Remove Favorite' a delete request is sent to "/favorites/:pet_id".
+      - [] After clicking remain in Favorites page.
+      - [] Favorites count decreased by one.
+
 
 ### User Story 14, No Favorites Page
 - [ ] done

--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -11,7 +11,7 @@ class PetsController < ApplicationController
     @shelter_id = params[:shelter_id]
   end
 
-   def create
+  def create
       shelter = Shelter.find(params[:shelter_id])
       pet = shelter.pets.create(pet_params)
       redirect_to("/shelters/#{shelter.id}/pets")

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -1,20 +1,20 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Favorited Pets Index</title>
+    <link rel="stylesheet" href="style.css">
+  </head>
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Favorited Pets Index</title>
-  <link rel="stylesheet" href="style.css">
-</head>
+  <body>
 
-<body>
-  <% @favorites.each do |pet| %>
-  <%= image_tag(pet.image, alt: pet.name, class: "pet-index-image") %>
-  <nav class="name">
-    <h1> <a href="/pets/<%= pet.id %>"><%= pet.name %></a></h1>
-  </nav>
-<%end%>
-</body>
-
+    <div class="grid-pet-container pet">
+        <% @favorites.each do |pet| %>
+          <%= image_tag(pet.image, alt: pet.name, class: "pet-index-image") %>
+          <nav class="name"> <h1> <a href="/pets/<%= pet.id %>"><%= pet.name %></a></h1></nav>
+        <%end%>
+      </div>
+      
+  </body>
 </html>

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -12,7 +12,10 @@
     <div class="grid-pet-container pet">
         <% @favorites.each do |pet| %>
           <%= image_tag(pet.image, alt: pet.name, class: "pet-index-image") %>
-          <nav class="name"> <h1> <a href="/pets/<%= pet.id %>"><%= pet.name %></a></h1></nav>
+          <nav class="name"> <h1> 
+            <a href="/pets/<%= pet.id %>"><%= pet.name %></a></h1>
+            <%= link_to "Remove Favorite", toogle_favorite_pet_path(pet),  method: :patch %>
+          </nav>
         <%end%>
       </div>
       

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -9,13 +9,13 @@
 
   <body>
 
-    <div class="grid-pet-container pet">
+    <div class="grid-pet-container}">
         <% @favorites.each do |pet| %>
-          <%= image_tag(pet.image, alt: pet.name, class: "pet-index-image") %>
-          <nav class="name"> <h1> 
-            <a href="/pets/<%= pet.id %>"><%= pet.name %></a></h1>
-            <%= link_to "Remove Favorite", toogle_favorite_pet_path(pet),  method: :patch %>
-          </nav>
+          <div id= <%= "pet-#{pet.id}" %>>
+            <%= image_tag(pet.image, alt: pet.name, class: "pet-index-image") %>
+            <nav class="name"> <h1><a href="/pets/<%= pet.id %>"><%= pet.name %></a></h1></nav>
+            <ul><%= link_to "Remove Favorite", toogle_favorite_pet_path(pet),  method: :patch %></ul>
+          </div>
         <%end%>
       </div>
       

--- a/app/views/shelters/pets_index.html.erb
+++ b/app/views/shelters/pets_index.html.erb
@@ -9,7 +9,7 @@
   </head>
 
   <body>
-   <div class="main_container">
+  <div class="main_container">
       <nav>
         <a href="/">HOME</a>
         <a href="/shelters">SHELTERS</a>
@@ -30,7 +30,7 @@
 
                 <%= image_tag(pet.image, alt: pet.name, class: "pet-index-image") %>
 
-               <nav class="name"> <h1> <a href="/pets/<%= pet.id %>"><%= pet.name %></a></h1> </nav>
+              <nav class="name"> <h1> <a href="/pets/<%= pet.id %>"><%= pet.name %></a></h1> </nav>
 
                 <div class="info">
                   <ul>Age: <%= pet.age %></ul>

--- a/spec/features/favorites/index_spec.rb
+++ b/spec/features/favorites/index_spec.rb
@@ -41,26 +41,26 @@ RSpec.describe "pets index page" do
 
     it "There is a 'Remove Favorite' link next to each pet in Favorites index page" do
       visit "/favorites"
-      within '.grid-pet-container' do
+      within("#pet-#{@pet_2.id}") do
         expect(page).to have_link("Remove Favorite")
       end
     end
 
-    # it "Clicking 'Remove Favorite' toggles ':favorite' to false, visitor remains in Favorites page" do
-    #   visit "/favorites"
-    #   expect(page).to have_content("Puppy2")
-    #   expect(page).to have_content("Puppy3")
+    it "Clicking 'Remove Favorite' toggles ':favorite' to false, visitor remains in Favorites page" do
+      visit "/favorites"
+      expect(page).to have_content("Puppy2")
+      expect(page).to have_content("Puppy3")
 
-    #   within '.grid-pet-container' do
-    #     if expect(page).to have_content("Puppy2")
-    #     click_link "Remove Favorite"
-    #     end
-    #   end
+      within("#pet-#{@pet_2.id}") do
+        click_link "Remove Favorite"
+      end
 
-    #   expect(page).to have_content("Puppy3")
-    #   expect(page).to_not have_content("Puppy2")
+      visit "/favorites"
+      expect(page).to have_content("Puppy3")
+      expect(page).to_not have_content("Puppy2")
+
       
-    # end
+    end
 
     # it "Favorite count in nav bar is updated after clicking 'Remove Favorite' link" do
     #   visit "/favorites"

--- a/spec/features/favorites/index_spec.rb
+++ b/spec/features/favorites/index_spec.rb
@@ -62,20 +62,18 @@ RSpec.describe "pets index page" do
       
     end
 
-    # it "Favorite count in nav bar is updated after clicking 'Remove Favorite' link" do
-    #   visit "/favorites"
-    #   expect(page).to have_content("Puppy2")
-    #   expect(page).to have_content("Puppy3")
+    it "Favorite count in nav bar is updated after clicking 'Remove Favorite' link" do
+      visit "/favorites"
+      expect(page).to have_content("Puppy2")
+      expect(page).to have_content("Puppy3")
 
-    #   within '.grid-pet-container' do
-    #     if expect(page).to have_content("Puppy2")
-    #     click_link "Remove Favorite"
-    #     end
-    #   end
+      within("#pet-#{@pet_2.id}") do
+        click_link "Remove Favorite"
+      end
 
-    #   within '.topnav' do
-    #     expect(page).to have_content("Favorite 1")
-    #   end
-    # end
+      within '.topnav' do
+        expect(page).to have_content("Favorite 1")
+      end
+    end
   end
 end

--- a/spec/features/favorites/index_spec.rb
+++ b/spec/features/favorites/index_spec.rb
@@ -12,26 +12,70 @@ RSpec.describe "pets index page" do
     @pet_4 = Pet.create!(image: "cat.jpg", name: "Kitten1", age: 2, sex: "Male", shelter_id: @shelter_2.id, favorite: "false")
   end
 
-  it " There is a '/favorites' index page, and Favorite pets are listed there" do
-    visit "/favorites"
-    expect(current_path).to eq("/favorites")
-    expect(page).to have_content("Puppy2")
-    expect(page).to have_content("Puppy3")
+  describe " There is a '/favorites' index page, and Favorite pets are listed there" do
+    
+    it "Pets are listed at '/favorites'" do
+      visit "/favorites"
+      expect(current_path).to eq("/favorites")
+      expect(page).to have_content("Puppy2")
+      expect(page).to have_content("Puppy3")
+    end
+
+    it "Displays pet's image and pet's name is a link to pet's show page" do
+      visit "/favorites"
+      expect(page).to have_selector(:link_or_button, 'Puppy2')
+      expect(page).to have_xpath("//img['brown_puppy.jpg']")
+    end
+
+    it "Favorites pets count is incremented after clicking 'Favorite'" do
+      visit "/pets/#{@pet_1.id}"
+      click_on "Favorite"
+      @pet_1.reload
+      visit "/pets"
+      expect(page).to have_content("Favorite 3")
+    end
   end
 
-  it "Displays pet's image and pet's name is a link to pet's show page" do
-    visit "/favorites"
-    expect(page).to have_selector(:link_or_button, 'Puppy2')
-    expect(page).to have_xpath("//img['brown_puppy.jpg']")
-  end
 
-  it "Displays pet's image and pet's name is a link to pet's show page" do
-    visit "/pets/#{@pet_1.id}"
-    click_on "Favorite"
-    @pet_1.reload
-    visit "/pets"
-    expect(page).to have_content("Favorite 3")
-    expect(page).to have_selector(:link_or_button, 'Favorite')
-    expect(page).to have_xpath("//img['brown_puppy.jpg']")
+  describe "Remove a Favorite from Favorites page" do
+
+    it "There is a 'Remove Favorite' link next to each pet in Favorites index page" do
+      visit "/favorites"
+      within '.grid-pet-container' do
+        expect(page).to_not have_selector(:link_or_button, 'Remove Favorite')
+      end
+    end
+
+    it "Clicking 'Remove Favorite' toggles ':favorite' to false, visitor remains in Favorites page" do
+      visit "/favorites"
+      expect(page).to have_content("Puppy2")
+      expect(page).to have_content("Puppy3")
+
+      within '.grid-pet-container' do
+        if expect(page).to have_content("Puppy2")
+        click_button "Remove Favorite"
+        end
+      end
+
+      expect(page).to have_content("Puppy3")
+      expect(page).to_not have_content("Puppy2")
+      
+    end
+
+    it "Favorite count in nav bar is updated after clicking 'Remove Favorite' link" do
+      visit "/favorites"
+      expect(page).to have_content("Puppy2")
+      expect(page).to have_content("Puppy3")
+
+      within '.grid-pet-container' do
+        if expect(page).to have_content("Puppy2")
+        click_button "Remove Favorite"
+        end
+      end
+
+      within '.topnav' do
+        expect(page).to have_content("Favorite 1")
+      end
+    end
   end
 end

--- a/spec/features/favorites/index_spec.rb
+++ b/spec/features/favorites/index_spec.rb
@@ -42,40 +42,40 @@ RSpec.describe "pets index page" do
     it "There is a 'Remove Favorite' link next to each pet in Favorites index page" do
       visit "/favorites"
       within '.grid-pet-container' do
-        expect(page).to_not have_selector(:link_or_button, 'Remove Favorite')
+        expect(page).to have_link("Remove Favorite")
       end
     end
 
-    it "Clicking 'Remove Favorite' toggles ':favorite' to false, visitor remains in Favorites page" do
-      visit "/favorites"
-      expect(page).to have_content("Puppy2")
-      expect(page).to have_content("Puppy3")
+    # it "Clicking 'Remove Favorite' toggles ':favorite' to false, visitor remains in Favorites page" do
+    #   visit "/favorites"
+    #   expect(page).to have_content("Puppy2")
+    #   expect(page).to have_content("Puppy3")
 
-      within '.grid-pet-container' do
-        if expect(page).to have_content("Puppy2")
-        click_button "Remove Favorite"
-        end
-      end
+    #   within '.grid-pet-container' do
+    #     if expect(page).to have_content("Puppy2")
+    #     click_link "Remove Favorite"
+    #     end
+    #   end
 
-      expect(page).to have_content("Puppy3")
-      expect(page).to_not have_content("Puppy2")
+    #   expect(page).to have_content("Puppy3")
+    #   expect(page).to_not have_content("Puppy2")
       
-    end
+    # end
 
-    it "Favorite count in nav bar is updated after clicking 'Remove Favorite' link" do
-      visit "/favorites"
-      expect(page).to have_content("Puppy2")
-      expect(page).to have_content("Puppy3")
+    # it "Favorite count in nav bar is updated after clicking 'Remove Favorite' link" do
+    #   visit "/favorites"
+    #   expect(page).to have_content("Puppy2")
+    #   expect(page).to have_content("Puppy3")
 
-      within '.grid-pet-container' do
-        if expect(page).to have_content("Puppy2")
-        click_button "Remove Favorite"
-        end
-      end
+    #   within '.grid-pet-container' do
+    #     if expect(page).to have_content("Puppy2")
+    #     click_link "Remove Favorite"
+    #     end
+    #   end
 
-      within '.topnav' do
-        expect(page).to have_content("Favorite 1")
-      end
-    end
+    #   within '.topnav' do
+    #     expect(page).to have_content("Favorite 1")
+    #   end
+    # end
   end
 end


### PR DESCRIPTION
### User Story 13, Remove a Favorite from Favorites Page
- [x] done

As a visitor
When I have added pets to my favorites list
And I visit my favorites page ("/favorites")
Next to each pet, I see a button or link to remove that pet from my favorites
When I click on that button or link to remove a favorite
A delete request is sent to "/favorites/:pet_id"
And I'm redirected back to the favorites page where I no longer see that pet listed
And I also see that the favorites indicator has decremented by 1

#### Notes & To_do
  - [x] Set up tests
    When I have added pets to my favorites list
    - [x] visit my favorites page and a 'remove favorite' link is visible next to EACH pet.
    - [x] Clicking 'Remove Favorite' a delete request is sent to "/favorites/:pet_id".
      - [x] After clicking remain in Favorites page.
      - [x] Favorites count decreased by one.