### PR TITLE
No favorites in page

### DIFF
--- a/NICO_NOTES.md
+++ b/NICO_NOTES.md
@@ -99,7 +99,7 @@ And I also see that my favorites indicator has decremented by 1
 
 
 ### User Story 13, Remove a Favorite from Favorites Page
-- [ ] done
+- [x] done
 
 As a visitor
 When I have added pets to my favorites list

--- a/NICO_NOTES.md
+++ b/NICO_NOTES.md
@@ -120,7 +120,7 @@ And I also see that the favorites indicator has decremented by 1
 
 
 ### User Story 14, No Favorites Page
-- [ ] done
+- [x] done
 
 As a visitor
 When I have not added any pets to my favorites list

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -8,8 +8,15 @@
   </head>
 
   <body>
+    
+    <% if @favorites.empty? %>
+    <br>
+    <%= "You haven't favorited any pets" %>
+    <br>
 
-    <div class="grid-pet-container}">
+    <% else %>
+
+      <div class="grid-pet-container}">
         <% @favorites.each do |pet| %>
           <div id= <%= "pet-#{pet.id}" %>>
             <%= image_tag(pet.image, alt: pet.name, class: "pet-index-image") %>
@@ -18,6 +25,8 @@
           </div>
         <%end%>
       </div>
-      
+
+    <% end %>
+
   </body>
 </html>

--- a/spec/features/favorites/index_spec.rb
+++ b/spec/features/favorites/index_spec.rb
@@ -82,16 +82,21 @@ RSpec.describe "pets index page" do
       visit "/favorites"
       expect(page).to have_content("Puppy2")
       expect(page).to have_content("Puppy3")
+
       within("#pet-#{@pet_2.id}") do
         click_link "Remove Favorite"
       end
+
+      visit "/favorites"
+      expect(page).to_not have_content("Puppy2")
+
       within("#pet-#{@pet_3.id}") do
         click_link "Remove Favorite"
       end
-      expect(page).to_not have_content("Puppy2")
-      expect(page).to_not have_content("Puppy3")
 
-      expect(page).to have_content("You haven't favorited any pets!")
+      visit "/favorites"
+      expect(page).to_not have_content("Puppy3")
+      expect(page).to have_content("You haven't favorited any pets")
     end
   end
 end

--- a/spec/features/favorites/index_spec.rb
+++ b/spec/features/favorites/index_spec.rb
@@ -76,4 +76,22 @@ RSpec.describe "pets index page" do
       end
     end
   end
+
+  describe "If there are No Favorites in Favorites page there is a message saying so " do
+    it "displays 'no favorites' message" do
+      visit "/favorites"
+      expect(page).to have_content("Puppy2")
+      expect(page).to have_content("Puppy3")
+      within("#pet-#{@pet_2.id}") do
+        click_link "Remove Favorite"
+      end
+      within("#pet-#{@pet_3.id}") do
+        click_link "Remove Favorite"
+      end
+      expect(page).to_not have_content("Puppy2")
+      expect(page).to_not have_content("Puppy3")
+
+      expect(page).to have_content("You haven't favorited any pets!")
+    end
+  end
 end


### PR DESCRIPTION
### User Story 14, No Favorites Page
- [x] done

As a visitor
When I have not added any pets to my favorites list
And I visit my favorites page ("/favorites")
I see text saying that I have no favorited pets

##### Tasks completed
- [x] Created features tests. I had some issues having to revisit the page to show the changes. I haven't sorted out yet why.
- [x] Added ruby code to the html.erb page to have a conditional that if @favorites was empty to display a message that no pets have been favorited yet.