### PR TITLE
Remove all favorites

### DIFF
--- a/NICO_NOTES.md
+++ b/NICO_NOTES.md
@@ -143,8 +143,8 @@ And the favorites indicator returns to 0
 #### Notes & To_do
   - [x] Set up tests
     When I have added pets to my favorites list
-    - [] visit my favorites page and ONE 'remove all favorite' link is visible.
-    - [] Clicking 'Remove All Favorite' removes all favorited pets.
-      - [] After clicking remain in Favorites page.
-      - [] I see the text saying that I have no favorited pets.
-      - [] Favorites count decreased to zero.
+    - [x] visit my favorites page and ONE 'remove all favorite' link is visible.
+    - [x] Clicking 'Remove All Favorite' removes all favorited pets.
+      - [x] After clicking remain in Favorites page.
+      - [x] I see the text saying that I have no favorited pets.
+      - [x] Favorites count decreased to zero.

--- a/NICO_NOTES.md
+++ b/NICO_NOTES.md
@@ -139,3 +139,12 @@ When I click that link
 I'm redirected back to the favorites page
 I see the text saying that I have no favorited pets
 And the favorites indicator returns to 0
+
+#### Notes & To_do
+  - [x] Set up tests
+    When I have added pets to my favorites list
+    - [] visit my favorites page and ONE 'remove all favorite' link is visible.
+    - [] Clicking 'Remove All Favorite' removes all favorited pets.
+      - [] After clicking remain in Favorites page.
+      - [] I see the text saying that I have no favorited pets.
+      - [] Favorites count decreased to zero.

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -2,4 +2,5 @@ class FavoritesController < ApplicationController
   def index
     @favorites = Pet.where(favorite: "true")
   end
+
 end

--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -44,6 +44,11 @@ class PetsController < ApplicationController
     # render :new
   end
 
+  def remove_all_favorites
+    @pets = Pet.all
+    @pets.total_favorites.map {|pet| pet.update(favorite: !pet.favorite)}
+  end
+
   private
   def pet_params
     params.permit(:image, :name, :age, :sex, :description, :status, :shelter_id, :favorite)

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -6,5 +6,9 @@ class Pet < ApplicationRecord
   def self.favorites
     Pet.where(favorite: "true").count
   end
-
+  
+  def self.total_favorites
+    Pet.where(favorite: "true")
+  end
+    
 end

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -28,5 +28,6 @@
 
     <% end %>
 
+    <%= link_to "Remove All Favorites", "/favorites", method: :delete %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,8 +20,8 @@
   
   <body>
     <% flash.each do |type, message| %>
-     <p><%= message %></p>
-     <% end %>
+      <p><%= message %></p>
+      <% end %>
 
     <%= yield %>
   </body>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
   end
 
   get '/favorites', to: 'favorites#index'
+  delete '/favorites', to: 'pets#remove_all_favorites'
  
   #reviews
   get '/shelters/:shelter_id/reviews/new', to: 'reviews#new'

--- a/spec/features/favorites/index_spec.rb
+++ b/spec/features/favorites/index_spec.rb
@@ -99,4 +99,25 @@ RSpec.describe "pets index page" do
       expect(page).to have_content("You haven't favorited any pets")
     end
   end
+
+  describe "A 'Remove All Favorites' link removes all pets from favorites once clicked. This displays a message that no pets have been favorited and reduces favorites count to zero" do
+    it "'Remove All Favorites' link function" do
+      visit "/favorites"
+      expect(page).to have_content("Puppy2")
+      expect(page).to have_content("Puppy3")
+      expect(page).to have_link("Remove All Favorites")
+
+      click_link "Remove All Favorites"
+      
+      visit "/favorites"
+
+      expect(page).to_not have_content("Puppy2")
+      expect(page).to_not have_content("Puppy3")
+      expect(page).to have_content("You haven't favorited any pets")
+
+      within '.topnav' do
+        expect(page).to have_content("Favorite 0")
+      end
+    end
+  end
 end


### PR DESCRIPTION
### User Story 15, Remove all Favorite from Favorites Page
- [x] done

As a visitor
When I have added pets to my favorites list
And I visit my favorites page ("/favorites")
I see a link to remove all favorited pets
When I click that link
I'm redirected back to the favorites page
I see the text saying that I have no favorited pets
And the favorites indicator returns to 0

#### Notes & To_do
  - [x] Set up tests
    When I have added pets to my favorites list
    - [x] visit my favorites page and ONE 'remove all favorite' link is visible.
    - [x] Clicking 'Remove All Favorite' removes all favorited pets.
      - [x] After clicking remain in Favorites page.
      - [x] I see the text saying that I have no favorited pets.
      - [x] Favorites count decreased to zero.